### PR TITLE
Get vote count

### DIFF
--- a/backend/planner-service/__tests__/unit/vote/vote-getVoteCountByObjectId.spec.ts
+++ b/backend/planner-service/__tests__/unit/vote/vote-getVoteCountByObjectId.spec.ts
@@ -1,0 +1,87 @@
+import sinon from 'sinon';
+import {
+  describe,
+  expect,
+  it,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import { Request, Response, NextFunction } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import VoteService from '../../../src/services/vote';
+import { VoteModel } from '../../../src/models/Vote';
+
+describe('Vote->getVoteCountByObjectId', () => {
+  let voteMock: sinon.SinonMock;
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let next: Partial<NextFunction> = jest.fn();
+
+  const existingVotes = {
+    objectId: { id: '671ceaae117001732cd0fc83', collection: 'Destination' },
+    upVotes: ['671d24c18132583fe9fb978f'],
+    downVotes: ['671d24c18132583fe9fb979f'],
+    _id: '671d119e14be184dbc5c0d90',
+  };
+
+  const newEmptyVotes = {
+    objectId: { id: '671ceaae117001732cd0fc83', collection: 'Destination' },
+    upVotes: [],
+    downVotes: [],
+    _id: '671d119e14be184dbc5c0d91',
+  };
+
+  beforeEach(() => {
+    voteMock = sinon.mock(VoteModel);
+    req = {
+      body: {
+        out: {
+          objectId: existingVotes.objectId.id,
+          type: existingVotes.objectId.collection,
+        },
+      },
+    };
+    res = {};
+  });
+
+  afterEach(() => {
+    voteMock.restore();
+  });
+
+  it('should return the count of upvotes and downvotes for existing votes', async () => {
+    voteMock.expects('findOne').resolves(existingVotes);
+
+    await VoteService.getVoteCountByObjectId(
+      req as Request,
+      res as Response,
+      next as NextFunction,
+    );
+
+    voteMock.verify();
+    expect(req.body.result).toEqual({ upVoteCount: 1, downVoteCount: 1 });
+    expect(req.body.status).toEqual(StatusCodes.OK);
+  });
+
+  it('should return zero counts when no votes exist', async () => {
+    voteMock.expects('findOne').resolves(null);
+    voteMock
+      .expects('create')
+      .withArgs({
+        objectId: newEmptyVotes.objectId,
+        upVotes: [],
+        downVotes: [],
+      })
+      .resolves(newEmptyVotes);
+
+    await VoteService.getVoteCountByObjectId(
+      req as Request,
+      res as Response,
+      next as NextFunction,
+    );
+
+    voteMock.verify();
+    expect(req.body.result).toEqual({ upVoteCount: 0, downVoteCount: 0 });
+    expect(req.body.status).toEqual(StatusCodes.OK);
+  });
+});

--- a/backend/planner-service/src/controllers/vote.ts
+++ b/backend/planner-service/src/controllers/vote.ts
@@ -32,6 +32,13 @@ const VoteRouteSchema = {
       type: ValidCollectionSchema,
     }),
   }),
+
+  getVoteCountByObjectId: ReqAttrSchema.extend({
+    query: z.object({
+      objectId: ObjectIdStringSchema,
+      type: ValidCollectionSchema,
+    }),
+  }),
   isUserVoted: ReqAttrSchema.extend({
     query: z.object({
       objectId: ObjectIdStringSchema,

--- a/backend/planner-service/src/routes/vote.ts
+++ b/backend/planner-service/src/routes/vote.ts
@@ -40,3 +40,10 @@ voteRouter.delete(
   UserService.verifyUserExists,
   VoteService.removeVote,
 )
+
+voteRouter.get(
+  '/count',
+  VoteValidator.getVotesByObjectId,
+  RequestUtils.verifyObjectExistInCollection,
+  VoteService.getVoteCountByObjectId,
+);

--- a/backend/planner-service/src/services/vote.ts
+++ b/backend/planner-service/src/services/vote.ts
@@ -174,10 +174,11 @@ const getVoteCountByObjectId = async (req: Request, res: Response, next: NextFun
     });
   }
 
-  const upVoteCount = existingVotes.upVotes.length;
-  const downVoteCount = existingVotes.downVotes.length;
 
-  req.body.result = { upVoteCount, downVoteCount };
+  req.body.result = {
+    upVoteCount: existingVotes.upVotes.length,
+    downVoteCount: existingVotes.downVotes.length,
+  };
   req.body.status = StatusCodes.OK;
   next();
 };

--- a/backend/planner-service/src/services/vote.ts
+++ b/backend/planner-service/src/services/vote.ts
@@ -150,6 +150,40 @@ const getVotesByObjectId = async (req: Request, res: Response, next: NextFunctio
 }
 
 /**
+ * Retrieves the number of upvotes and downvotes for an object in the planner with the given objectId and type.
+ *
+ * If the vote document does not exist, this endpoint will create a new vote document
+ * with an empty array of upvotes and downvotes, and return a count of 0 for each.
+ *
+ * @param req - The incoming request from the client.
+ * @param res - The response to the client.
+ * @param next - The next function in the middleware chain.
+ */
+const getVoteCountByObjectId = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  const { objectId: oid, type } = req.body.out;
+  let existingVotes = await VoteModel.findOne({
+    objectId: { id: oid, collection: type },
+  });
+
+  if (!existingVotes) {
+    // Create a new document if none exists
+    existingVotes = await VoteModel.create({
+      objectId: { id: oid, collection: type },
+      upVotes: [],
+      downVotes: [],
+    });
+  }
+
+  const upVoteCount = existingVotes.upVotes.length;
+  const downVoteCount = existingVotes.downVotes.length;
+
+  req.body.result = { upVoteCount, downVoteCount };
+  req.body.status = StatusCodes.OK;
+  next();
+};
+
+
+/**
  * Checks if a user has voted on an object in the planner with the given objectId and type.
  *
  * If the vote document does not exist, this endpoint will return a 404 error.
@@ -189,5 +223,7 @@ const VoteService = {
   removeVote,
   getVotesByObjectId,
   isUserVoted,
+  getVoteCountByObjectId
 }
 export default VoteService
+


### PR DESCRIPTION
> Implemented a new route GET /vote/count to fetch the number of upvotes and downvotes for a specified object.

> Updated vote.ts service and controller to support counting votes by objectId and type.

> Added unit and integration tests to cover various scenarios, including:
  > Basic upvote and downvote counting.
  > Edge cases with multiple votes from different users.
  > Handling of vote removal and non-existent vote removal
